### PR TITLE
Call node with --trace-warnings for debugging

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -4,6 +4,6 @@
   ],
   "ext": "ts",
   "ignore": [],
-  "exec": "tsc && homebridge -I -D",
+  "exec": "tsc && node --trace-warnings `which homebridge` -I -D",
   "signal": "SIGTERM"
 }


### PR DESCRIPTION
Calling `node` with `--trace-warnings` can help with the debugging of event loops and associated memory leaks. This change implements this for the `nodemon` action for development.