### PR TITLE
Move unregisterPlatformAccessories

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -79,16 +79,22 @@ export class ExampleHomebridgePlatform implements DynamicPlatformPlugin {
 
       if (existingAccessory) {
         // the accessory already exists
-        this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
+        if (device) {
+          this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
 
-        // if you need to update the accessory.context then you should run `api.updatePlatformAccessories`. eg.:
-        // existingAccessory.context.device = device;
-        // this.api.updatePlatformAccessories([existingAccessory]);
+          // if you need to update the accessory.context then you should run `api.updatePlatformAccessories`. eg.:
+          // existingAccessory.context.device = device;
+          // this.api.updatePlatformAccessories([existingAccessory]);
 
-        // create the accessory handler for the restored accessory
-        // this is imported from `platformAccessory.ts`
-        new ExamplePlatformAccessory(this, existingAccessory);
-
+          // create the accessory handler for the restored accessory
+          // this is imported from `platformAccessory.ts`
+          new ExamplePlatformAccessory(this, existingAccessory);
+        } else if (!device) {
+          // it is possible to remove platform accessories at any time using `api.unregisterPlatformAccessories`, eg.:
+          // remove platform accessories when no longer present
+          this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
+          this.log.info('Removing existing accessory from cache:', existingAccessory.displayName);
+        }
       } else {
         // the accessory does not yet exist, so we need to create it
         this.log.info('Adding new accessory:', device.exampleDisplayName);
@@ -107,10 +113,6 @@ export class ExampleHomebridgePlatform implements DynamicPlatformPlugin {
         // link the accessory to your platform
         this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
       }
-
-      // it is possible to remove platform accessories at any time using `api.unregisterPlatformAccessories`, eg.:
-      // this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
     }
-
   }
 }


### PR DESCRIPTION
moved unregisterPlatformAccessories under existingAccessory since it will look for existing accessories and if no longer there it will remove it. Have it working like this on homebridge-honeywell-home, homebridge-honeywell-home-thermostat, homebridge-honeywell-home-roomsensors, and homebridge-honeywell-leak.