### PR TITLE
Bump required nodejs >= 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/USERNAME/GITHUB_PROJECT_NAME/issues"
   },
   "engines": {
-    "node": ">=10.17.0",
+    "node": ">=12",
     "homebridge": ">=1.3.0"
   },
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/USERNAME/GITHUB_PROJECT_NAME/issues"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=12.13.0",
     "homebridge": ">=1.3.0"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
Now homebride/verified requires nodejs >= 12 and `"node": ">=10.17.0"` is rejected to be verified.

- https://github.com/homebridge/verified/pull/331

This PR makes homebride plugin system more consitent by bumping required nodejs at template level.