### PR TITLE
Replace git protocol to https

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/USERNAME/GITHUB_PROJECT_NAME.git"
+    "url": "https://github.com/USERNAME/GITHUB_PROJECT_NAME.git"
   },
   "bugs": {
     "url": "https://github.com/USERNAME/GITHUB_PROJECT_NAME/issues"


### PR DESCRIPTION
GitHub have planned disable unencrypted `git://` protocol. We should use `https://`.
https://github.blog/2021-09-01-improving-git-protocol-security-github/