### PR TITLE
Add devcontainer definition

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:0-18-bullseye
+
+# Install homebridge
+RUN npm install -g --unsafe-perm homebridge homebridge-config-ui-x
+
+# Copy the default homebridge config
+RUN mkdir /home/node/.homebridge \
+    && chown node /home/node/.homebridge
+COPY homebridge-config/config.json /home/node/.homebridge/config.json
+COPY homebridge-config/auth.json /home/node/.homebridge/auth.json

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,8 +12,7 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"dbaeumer.vscode-eslint",
-				"eamodio.gitlens"
+				"dbaeumer.vscode-eslint"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Homebridge",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "homebridge",
+	"features": {},
+	"forwardPorts": [
+		51826,
+		8581
+	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"eamodio.gitlens"
+			]
+		}
+	},
+	"workspaceFolder": "/workspace"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  homebridge:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: always
+    network_mode: host
+    command: sleep infinity
+    volumes:
+      - ..:/workspace:cached

--- a/.devcontainer/homebridge-config/auth.json
+++ b/.devcontainer/homebridge-config/auth.json
@@ -1,0 +1,10 @@
+[
+    {
+        "id": 1,
+        "username": "admin",
+        "name": "admin",
+        "hashedPassword": "2a739a8c9faf3f58d1f1662c0ad09508125c46a1e306621ae89b7cb3ad43e074a09819e75a6b30a99c949a9abafd3dcf9f8a88e2f49b044d8ae1436fa46ccb30",
+        "salt": "82fdb7ee9d19003dbbe302bc14a00025f7dc982341abf8ac02d386648561124b",
+        "admin": true
+    }
+]

--- a/.devcontainer/homebridge-config/config.json
+++ b/.devcontainer/homebridge-config/config.json
@@ -20,8 +20,8 @@
             "platform": "config"
         },
         {
-            "name": "homebridge-plugin-name",
-            "platform": "ExampleHomebridgePlugin"
+            "name": "PLUGIN_NAME",
+            "platform": "PLATFORM_NAME"
         }
     ]
 }

--- a/.devcontainer/homebridge-config/config.json
+++ b/.devcontainer/homebridge-config/config.json
@@ -18,6 +18,10 @@
             "tempUnits": "c",
             "lang": "en",
             "platform": "config"
+        },
+        {
+            "name": "homebridge-plugin-name",
+            "platform": "ExampleHomebridgePlugin"
         }
     ]
 }

--- a/.devcontainer/homebridge-config/config.json
+++ b/.devcontainer/homebridge-config/config.json
@@ -1,0 +1,23 @@
+{
+    "bridge": {
+        "name": "Homebridge",
+        "username": "0E:DD:19:D5:34:EA",
+        "manufacturer": "homebridge.io",
+        "model": "homebridge",
+        "port": 51826,
+        "pin": "674-49-017",
+        "advertiser": "ciao"
+    },
+    "accessories": [],
+    "platforms": [
+        {
+            "name": "Config",
+            "port": 8581,
+            "auth": "none",
+            "theme": "auto",
+            "tempUnits": "c",
+            "lang": "en",
+            "platform": "config"
+        }
+    ]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -132,3 +132,6 @@ web_modules/
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+
+# devcontainer files
+.devcontainer

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Homebridge watch",
+            "request": "launch",
+            "type": "node",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run",
+                "watch"
+            ],
+            "preLaunchTask": "npm: install"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,10 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "npm: install",
+            "type": "npm",
+            "script": "install"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Open the [`config.json`](./.devcontainer/homebridge-config/config.json) and chan
 * `PLATFORM_NAME` - Set this to the `PLATFORM_NAME` you set in [`src/settings.ts`](./src/settings.ts)
 * `PLUGIN_NAME` - Set this to the `PLUGIN_NAME` you set in [`src/settings.ts`](./src/settings.ts)
 
-Furthermore you can define additional values that should be set when starting the development container.
+Furthermore you can define additional values that should be set when starting the Development Container. After you change the default configuration you have to rebuild your container so that the configuration will be updated.
 
 ## Build Plugin
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,17 @@ Click the link below to create a new GitHub Repository using this template, or c
 
 ## Setup Development Environment
 
-To develop Homebridge plugins you must have Node.js 12 or later installed, and a modern code editor such as [VS Code](https://code.visualstudio.com/). This plugin template uses [TypeScript](https://www.typescriptlang.org/) to make development easier and comes with pre-configured settings for [VS Code](https://code.visualstudio.com/) and ESLint. If you are using VS Code install these extensions:
+This plugin template uses [TypeScript](https://www.typescriptlang.org/) to make development easier and comes with pre-configured settings for [VS Code](https://code.visualstudio.com/) and ESLint. 
+
+### Local installation
+
+To develop Homebridge plugins you must have Node.js 12 or later installed, and a modern code editor such as [VS Code](https://code.visualstudio.com/). If you are using VS Code install these extensions:
 
 * [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+
+### Development Containers
+
+Alternatively you can use the [Development Containers](https://containers.dev) definition to create a container which already has everything installed you need for developing Homebridge plugins. To do so either use [Github Codespaces](https://github.com/features/codespaces) or use the [Remote Development extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) of [VS Code](https://code.visualstudio.com/).
 
 ## Install Development Dependencies
 
@@ -57,6 +65,15 @@ Open the [`src/settings.ts`](./src/settings.ts) file and change the default valu
 Open the [`config.schema.json`](./config.schema.json) file and change the following attribute:
 
 * `pluginAlias` - set this to match the `PLATFORM_NAME` you defined in the previous step.
+
+## Update Development Container configuration (optional)
+
+Open the [`config.json`](./.devcontainer/homebridge-config/config.json) and change the default values:
+
+* `PLATFORM_NAME` - Set this to the `PLATFORM_NAME` you set in [`src/settings.ts`](./src/settings.ts)
+* `PLUGIN_NAME` - Set this to the `PLUGIN_NAME` you set in [`src/settings.ts`](./src/settings.ts)
+
+Furthermore you can define additional values that should be set when starting the development container.
 
 ## Build Plugin
 


### PR DESCRIPTION
## :recycle: Current situation

The main benefit of the devcontainers for me is that I have everything set up and ready to go after a few minutes and do not have to struggle with setting up node, homebridge, etc. So I went with creating a devcontainer which contains a basic homebridge instance already set up and ready to use.

## :bulb: Proposed solution

Add a ready-to-use devcontainer definition.

## :gear: Release Notes

- added devcontainer definition files

## :heavy_plus_sign: Additional Information

The main benefit of the devcontainers for me is that I have everything set up and ready to go after a few minutes and do not have to struggle with setting up node, homebridge, etc. So I went with creating a devcontainer which contains a basic homebridge instance already set up and ready to use. 

I prepared a branch which contains the definition files needed to get it working. I can not push it because of permissions but you can check this [repository](https://github.com/o-lukas/homebridge-smartthings-tv/tree/main/.devcontainer) for the definition I used for my first plugin. If you tell me how to publish the branch I prepared I can do this of course so you can see the definition without my plugin specific stuff.

### Testing

I have used the container for developing a plugin and have fixed the issues I have found while using it. So I think there should be no (major) problems.

### Reviewer Nudging
