### PR TITLE
Update package to permit node version 20.9.x, fixes #62

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "engines": {
         "homebridge": "^1.6.0",
-        "node": "^18.17.0"
+        "node": "^18.17.0 || ^20.9.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/USERNAME/GITHUB_PROJECT_NAME/issues"
   },
   "engines": {
-    "node": "^18.17.0",
+    "node": "^18.17.0 || ^20.9.0",
     "homebridge": "^1.6.0"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
Code review and testing requested.

Removes the warning message from log...
`The plugin "<name-your-pligin>" requires Node.js version of ^18.17.0 which does not satisfy the current Node.js version of v20.9.0. You may need to upgrade your installation of Node.js - see https://homebridge.io/w/JTKEF`
