### PR TITLE
Update nodemon version to resolve CVE-2022-25883 

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^8.45.0",
     "homebridge": "^1.6.0",
-    "nodemon": "^2.0.22",
+    "nodemon": "^3.0.3",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"


### PR DESCRIPTION
## :recycle: Current situation

*Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets).*

There is a vulnerability in the version of server installed. https://github.com/advisories/GHSA-c2qf-rxjj-qqgw

## :bulb: Proposed solution

*Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?*

Update the nodemon dependancy to ^3.0.3 to install the allow a patched version of server to install.

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

nodemon 3.0.0 is a breaking change so this will need to be reviewed.