### PR TITLE
Update sample to reflect release of Homebridge 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "dist/index.js",
   "engines": {
     "node": "^20.18.0 || ^22.10.0 || ^24.0.0",
-    "homebridge": "^1.8.0 || ^2.0.0-beta.0"
+    "homebridge": "^1.8.0 || ^2.0.0"
   },
   "scripts": {
     "build": "rimraf ./dist && tsc",


### PR DESCRIPTION
## :recycle: Current situation

Example still uses `"homebridge": "^1.8.0 || ^2.0.0-beta.0"` despite Homebridge 2 being officially released

## :bulb: Proposed solution

Drops the `-beta.0` release tag from Homebridge 2 references.

## :gear: Release Notes

Users creating a new plugin from this template will have up-to-date Homebridge 2 support from Day 1.

## :heavy_plus_sign: Additional Information

Lines up with documentation changes in https://github.com/homebridge/homebridge-plugin-template/pull/89

### Testing

N/A

### Reviewer Nudging

_Where should the reviewer start? what is a good entry point?_
